### PR TITLE
feat: 为文档主页添加 GitHub 项目直达链接图标

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -60,6 +60,9 @@ export default defineConfig({
             message: "赞助：<a href='https://afdian.com/a/mojinran'>爱发电</a>",
             copyright: "基于 <a href='https://github.com/LiteLoaderQQNT/LiteLoaderQQNT/blob/main/LICENSE'>MIT</a> 许可发布"
         },
+        socialLinks: [
+          { icon: 'github', link: 'https://github.com/LiteLoaderQQNT/LiteLoaderQQNT' }
+        ],
         externalLinkIcon: true
     }
 });


### PR DESCRIPTION
本地测试无问题：

<img width="1890" height="485" alt="image" src="https://github.com/user-attachments/assets/f5ede725-2571-4410-a3a4-8f2d1569ce74" />
